### PR TITLE
fix: change >= to > on totalSupply check

### DIFF
--- a/src/ERC721Token.sol
+++ b/src/ERC721Token.sol
@@ -26,7 +26,7 @@ contract ERC721Token is LilOwnable, ERC721 {
     }
 
     function mint(uint16 amount) external payable {
-        if (totalSupply + amount >= TOTAL_SUPPLY) revert NoTokensLeft();
+        if (totalSupply + amount > TOTAL_SUPPLY) revert NoTokensLeft();
         if (msg.value < amount * PRICE_PER_MINT) revert NotEnoughETH();
 
         unchecked {


### PR DESCRIPTION
- right now the check is `>=` so when for example `totalSupply` == `9999` and a person wants to mint `1` it will be reverted because it's `>=` the max supply which is 10,000.